### PR TITLE
Add default value to 'appauthor' on wrapper

### DIFF
--- a/lib/appdirs.py
+++ b/lib/appdirs.py
@@ -216,7 +216,7 @@ def user_log_dir(appname, appauthor=None, version=None, opinion=True):
 
 class AppDirs(object):
     """Convenience wrapper for getting application dirs."""
-    def __init__(self, appname, appauthor, version=None, roaming=False):
+    def __init__(self, appname, appauthor=None, version=None, roaming=False):
         self.appname = appname
         self.appauthor = appauthor
         self.version = version


### PR DESCRIPTION
Simple change to add a default argument value to `appauthor` in the `AppDirs` wrapper, since this argument is optional in all the functions it calls.
