### PR TITLE
Get rid of Komodo drop-ins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 dist/
 .tox/
 MANIFEST
+*.komodoproject

--- a/appdirs.komodoproject
+++ b/appdirs.komodoproject
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Komodo Project File - DO NOT EDIT -->
-<project id="2e6d94c8-bff8-c042-8d71-c7fd78beb274" kpf_version="5" name="appdirs.komodoproject">
-<preference-set idref="2e6d94c8-bff8-c042-8d71-c7fd78beb274">
-  <boolean id="import_live">1</boolean>
-</preference-set>
-</project>


### PR DESCRIPTION
I don't think we should have any environment-related files in the public repo.
