### PR TITLE
Include missing test/__init__.py in source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.rst
 include CHANGES.rst
 include LICENSE.txt
 include *.py
+include test/*.py


### PR DESCRIPTION
test/**init**.py was missing in the 1.3.0 release and that causes the tests to fail.
