### PR TITLE
Update trove and tox with supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,14 @@ setup(
         License :: OSI Approved :: MIT License
         Operating System :: OS Independent
         Programming Language :: Python :: 2
-        Programming Language :: Python :: 2.4
-        Programming Language :: Python :: 2.5
         Programming Language :: Python :: 2.6
         Programming Language :: Python :: 2.7
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.1
         Programming Language :: Python :: 3.2
+        Programming Language :: Python :: 3.3
+        Programming Language :: Python :: 3.4
+        Programming Language :: Python :: Implementation :: PyPy
+        Programming Language :: Python :: Implementation :: CPython
         Topic :: Software Development :: Libraries :: Python Modules
         """.split('\n') if c.strip()],
     test_suite='test.test_api',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py24, py25, py26, py27, py31
+envlist = py26, py27, py32, py33, py34
 
 [testenv]
-commands = python test/test.py
+commands = python setup.py test


### PR DESCRIPTION
It seems that python 2.4 and 2.5 are no longer supported by tox and python 3.1 does not support unittest2
