### PR TITLE
support XDG_STATE_HOME

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -25,6 +25,8 @@ class Test_AppDir(unittest.TestCase):
         self.assertIsInstance(
             appdirs.user_cache_dir('MyApp', 'MyCompany'), STRING_TYPE)
         self.assertIsInstance(
+            appdirs.user_state_dir('MyApp', 'MyCompany'), STRING_TYPE)
+        self.assertIsInstance(
             appdirs.user_log_dir('MyApp', 'MyCompany'), STRING_TYPE)
 
     def test_dirs(self):
@@ -32,6 +34,7 @@ class Test_AppDir(unittest.TestCase):
         self.assertIsInstance(dirs.user_data_dir, STRING_TYPE)
         self.assertIsInstance(dirs.site_data_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_cache_dir, STRING_TYPE)
+        self.assertIsInstance(dirs.user_state_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_log_dir, STRING_TYPE)
 
 if __name__ == "__main__":


### PR DESCRIPTION
There is a proposal to add another directory type to the XDG Base Directory Specification.

https://wiki.debian.org/XDGBaseDirectorySpecification#state

To be clear, this is _not_ currently part of the specification.  However, I think it would be a valuable addition to the appdirs module.  I wasn't sure if there was an equivalent for OSX or Windows, so for now those fall back to using user_data_dir.
