### PR TITLE
Fix DeprecationWarning in Python 3.6

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -98,7 +98,7 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
 
 
 def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
-    """Return full path to the user-shared data dir for this application.
+    r"""Return full path to the user-shared data dir for this application.
 
         "appname" is the name of application.
             If None, just the system directory is returned.
@@ -204,7 +204,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
 
 
 def site_config_dir(appname=None, appauthor=None, version=None, multipath=False):
-    """Return full path to the user-shared data dir for this application.
+    r"""Return full path to the user-shared data dir for this application.
 
         "appname" is the name of application.
             If None, just the system directory is returned.


### PR DESCRIPTION
In Python 3.6, invalid escape sequences in string literals are deprecated: [1][2]

```
$ python3.6 -B -W error -c 'import appdirs'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
DeprecationWarning: invalid escape sequence '\D'
```

My patch fixes all of them.

[1] http://bugs.python.org/issue28128
[2] http://bugs.python.org/issue27364
