### PR TITLE
Allow installing without setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,11 @@
 import sys
 import os
 import os.path
-from setuptools import setup
+# appdirs is a dependency of setuptools, so allow installing without it.
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 import appdirs
 
 tests_require = []


### PR DESCRIPTION
Setuptools v34 requires appdirs, which creates an obvious bootstrap problem if appdirs uses setuptools in its setup.py. Therefore, allow installing with distutils if setuptools is not available.