### PR TITLE
Fix string delimiters in setup.py description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ def read(fname):
 setup(
     name='appdirs',
     version=appdirs.__version__,
-    description='A small Python module for determining appropriate " + \
-        "platform-specific dirs, e.g. a "user data dir".',
+    description='A small Python module for determining appropriate ' + \
+        'platform-specific dirs, e.g. a "user data dir".',
     long_description=read('README.rst') + '\n' + read('CHANGES.rst'),
     classifiers=[c.strip() for c in """
         Development Status :: 4 - Beta


### PR DESCRIPTION
Fixes #62.

### Before:
```
$ python setup.py --description
A small Python module for determining appropriate " +         "platform-specific dirs, e.g. a "user data dir".
```
### After:
```
$ python setup.py --description
A small Python module for determining appropriate platform-specific dirs, e.g. a "user data dir".
```
This also affects your description on [PyPI](https://pypi.python.org/pypi/appdirs).