### PR TITLE
Don't import appdirs from setup.py

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -13,8 +13,8 @@ See <http://github.com/ActiveState/appdirs> for details and usage.
 # - Mac OS X: http://developer.apple.com/documentation/MacOSX/Conceptual/BPFileSystem/index.html
 # - XDG spec for Un*x: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 
-__version_info__ = (1, 4, 3)
-__version__ = '.'.join(map(str, __version_info__))
+__version__ = "1.4.3"
+__version_info__ = tuple(int(segment) for segment in __version__.split("."))
 
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-import appdirs
+import ast
 
 tests_require = []
 if sys.version_info < (2, 7):
@@ -21,9 +21,16 @@ def read(fname):
     return out
 
 
+# Do not import `appdirs` yet, lest we import some random version on sys.path.
+for line in read("appdirs.py").splitlines():
+    if line.startswith("__version__"):
+        version = ast.literal_eval(line.split("=", 1)[1].strip())
+        break
+
+
 setup(
     name='appdirs',
-    version=appdirs.__version__,
+    version=version,
     description='A small Python module for determining appropriate ' + \
         'platform-specific dirs, e.g. a "user data dir".',
     long_description=read('README.rst') + '\n' + read('CHANGES.rst'),


### PR DESCRIPTION
In general, setup.py should never import the code it's trying to
install.

During a setup.py run, there is no guarantee that importing `appdirs`
will actually import the one in the same directory as `setup.py`.

Instead, read the version number out of `appdirs.py` by opening it.

Fixes: #91