### PR TITLE
do not load pywin32 dlls on Windows, in order to allow pywin32 upgrades

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 appdirs Changelog
 =================
 
+Next Release
+------------
+- [PR #] Do not load ``pywin32`` dlls on Windows, in order to allow ``pywin32`` to be upgraded
+
 appdirs 1.4.4
 -------------
 - [PR #92] Don't import appdirs from setup.py which resolves issue #91

--- a/appdirs.py
+++ b/appdirs.py
@@ -565,18 +565,14 @@ def _get_win_folder_with_jna(csidl_name):
 
 if system == "win32":
     try:
-        import win32com.shell
-        _get_win_folder = _get_win_folder_with_pywin32
+        from ctypes import windll
+        _get_win_folder = _get_win_folder_with_ctypes
     except ImportError:
         try:
-            from ctypes import windll
-            _get_win_folder = _get_win_folder_with_ctypes
+            import com.sun.jna
+            _get_win_folder = _get_win_folder_with_jna
         except ImportError:
-            try:
-                import com.sun.jna
-                _get_win_folder = _get_win_folder_with_jna
-            except ImportError:
-                _get_win_folder = _get_win_folder_from_registry
+            _get_win_folder = _get_win_folder_from_registry
 
 
 #---- self test code


### PR DESCRIPTION
on Windows when setuptools is imported, appdirs is imported and in turn it will import pywin32 if available, which will lock pywin32's dlls and because of that pywin32 cannot be updated anymore (your pip install command will fail too)

fix is to apply the same patch as the pip project did since their version 10.0 in https://github.com/pypa/pip/pull/4992

I've specifically made this PR here in the upstream so that the change will remain in the future in both setuptools and pip