### PR TITLE
Drop legacy distutils fallback in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
-import os
-# appdirs is a dependency of setuptools, so allow installing without it.
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
 import ast
+import os
+from setuptools import setup
 
 
 def read(fname):


### PR DESCRIPTION
distutils is not recommended for use and unnecessary for modern Python
environments. Use only setuptools instead. From
https://docs.python.org/3/library/distutils.html:

> Most Python users will not want to use this module directly, but
> instead use the cross-version tools maintained by the Python Packaging
> Authority. In particular, setuptools is an enhanced alternative to
> distutils ...
>
> The recommended pip installer runs all setup.py scripts with
> setuptools, even if the script itself only imports distutils. Refer to
> the Python Packaging User Guide for more information.