### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
+dist: xenial
 language: python
 python:
   - "2.7"
-  - "pypy"
+  - "pypy2.7-6.0"
   - "3.4"
   - "3.5"
   - "3.6"
-
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial
-      sudo: true
+  - "3.7"
+  - "pypy3.5-6.0"
 
 script: python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy, py34, py35, py36, py37
+envlist = py27, pypy, py34, py35, py36, py37, pypy3
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release

As pypy3 is tested on Travis, add it to tox.ini as well.