### PR TITLE
Add pathlib support

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -41,6 +41,16 @@ else:
     system = sys.platform
 
 
+def path_property(f):
+    @property
+    def wrapper(self):
+        if self.use_pathlib:
+            import pathlib
+            return pathlib.Path(f(self))
+        else:
+            return f(self)
+    return wrapper
+
 
 def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
     r"""Return full path to the user-specific data dir for this application.
@@ -415,44 +425,45 @@ def user_log_dir(appname=None, appauthor=None, version=None, opinion=True):
 class AppDirs(object):
     """Convenience wrapper for getting application dirs."""
     def __init__(self, appname=None, appauthor=None, version=None,
-            roaming=False, multipath=False):
+            roaming=False, multipath=False, use_pathlib=False):
         self.appname = appname
         self.appauthor = appauthor
         self.version = version
         self.roaming = roaming
         self.multipath = multipath
+        self.use_pathlib = use_pathlib
 
-    @property
+    @path_property
     def user_data_dir(self):
         return user_data_dir(self.appname, self.appauthor,
                              version=self.version, roaming=self.roaming)
 
-    @property
+    @path_property
     def site_data_dir(self):
         return site_data_dir(self.appname, self.appauthor,
                              version=self.version, multipath=self.multipath)
 
-    @property
+    @path_property
     def user_config_dir(self):
         return user_config_dir(self.appname, self.appauthor,
                                version=self.version, roaming=self.roaming)
 
-    @property
+    @path_property
     def site_config_dir(self):
         return site_config_dir(self.appname, self.appauthor,
                              version=self.version, multipath=self.multipath)
 
-    @property
+    @path_property
     def user_cache_dir(self):
         return user_cache_dir(self.appname, self.appauthor,
                               version=self.version)
 
-    @property
+    @path_property
     def user_state_dir(self):
         return user_state_dir(self.appname, self.appauthor,
                               version=self.version)
 
-    @property
+    @path_property
     def user_log_dir(self):
         return user_log_dir(self.appname, self.appauthor,
                             version=self.version)


### PR DESCRIPTION
Hello there.

As you must know, Python has since `3.4` included `pathlib` in the standard library as discussed in [PEP 428](https://www.python.org/dev/peps/pep-0428/). Long story short, it's a very nice API to the filesystem that now comes default with Python.

I understand that this software aims to have 0 dependencies and at the same time supports `python >=2.7.*`. This might be a bit of a blocker, but I tried to keep it as portable as possible, with minimal modifications:

- Only `AppDirs` class is modified. This means, all other functions/methods preserve their types and have no relationship to `pathlib`.
- `AppDirs` is added a new attribute `use_pathlib`, to determine whetever to use `pathlib`. It's `False` by default, to preserve backwards compability.
- The `property` decorator is replaced by a custom decorator `path_property`.
- `path_property` is still a property, but with an added check for the `use_pathlib` attribute. Only if it's true, does it import `pathlib` and coverts the path string to a Path object. If this branch is taken on a older Python installation, this will break, unless `pathlib` is explictily installed with `pip`.

Let me know your opinion on this.