### PR TITLE
Remove unused shebang from appdirs.py

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2005-2010 ActiveState Software Inc.
 # Copyright (c) 2013 Eddy Petrișor


### PR DESCRIPTION
The file is not marked as executable, so the shebang is never used by
the operating system. To execute appdirs from the command line, one can
continue to do:

    $ python -m appdirs
    -- app dirs 1.4.3 --
    -- app dirs (with optional 'version')
    user_data_dir: /home/jdufresne/.local/share/MyApp/1.0
    user_config_dir: /home/jdufresne/.config/MyApp/1.0
    user_cache_dir: /home/jdufresne/.cache/MyApp/1.0
    user_state_dir: /home/jdufresne/.local/state/MyApp/1.0
    user_log_dir: /home/jdufresne/.cache/MyApp/1.0/log
    site_data_dir: /home/jdufresne/.local/share/flatpak/exports/share/MyApp/1.0
    site_config_dir: /etc/xdg/MyApp/1.0

    -- app dirs (without optional 'version')
    user_data_dir: /home/jdufresne/.local/share/MyApp
    user_config_dir: /home/jdufresne/.config/MyApp
    user_cache_dir: /home/jdufresne/.cache/MyApp
    user_state_dir: /home/jdufresne/.local/state/MyApp
    user_log_dir: /home/jdufresne/.cache/MyApp/log
    site_data_dir: /home/jdufresne/.local/share/flatpak/exports/share/MyApp
    site_config_dir: /etc/xdg/MyApp

    -- app dirs (without optional 'appauthor')
    user_data_dir: /home/jdufresne/.local/share/MyApp
    user_config_dir: /home/jdufresne/.config/MyApp
    user_cache_dir: /home/jdufresne/.cache/MyApp
    user_state_dir: /home/jdufresne/.local/state/MyApp
    user_log_dir: /home/jdufresne/.cache/MyApp/log
    site_data_dir: /home/jdufresne/.local/share/flatpak/exports/share/MyApp
    site_config_dir: /etc/xdg/MyApp

    -- app dirs (with disabled 'appauthor')
    user_data_dir: /home/jdufresne/.local/share/MyApp
    user_config_dir: /home/jdufresne/.config/MyApp
    user_cache_dir: /home/jdufresne/.cache/MyApp
    user_state_dir: /home/jdufresne/.local/state/MyApp
    user_log_dir: /home/jdufresne/.cache/MyApp/log
    site_data_dir: /home/jdufresne/.local/share/flatpak/exports/share/MyApp
    site_config_dir: /etc/xdg/MyApp