### PR TITLE
Fix for Python 4: replace unsafe PY3 with PY2

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -20,9 +20,9 @@ __version_info__ = tuple(int(segment) for segment in __version__.split("."))
 import sys
 import os
 
-PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2
 
-if PY3:
+if not PY2:
     unicode = str
 
 if sys.platform.startswith('java'):
@@ -465,10 +465,10 @@ def _get_win_folder_from_registry(csidl_name):
     registry for this guarantees us the correct answer for all CSIDL_*
     names.
     """
-    if PY3:
-      import winreg as _winreg
+    if PY2:
+        import _winreg
     else:
-      import _winreg
+      import winreg as _winreg
 
     shell_folder_name = {
         "CSIDL_APPDATA": "AppData",


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code like this:

```python
PY3 = sys.version_info[0] == 3

if PY3:
    print("Python 3+ code")
else:
    print("Python 2 code")
```

When run on Python 4, this will run the Python 2 code!

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./appdirs.py:23:7: YTT201 `sys.version_info[0] == 3` referenced (python4), use `>=`
```