### PR TITLE
Treat empty environment variables like unset ones

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -41,6 +41,12 @@ else:
     system = sys.platform
 
 
+def getenv(name, default=None):
+    value = os.getenv(name)
+    if not value:
+        value = default
+    return value
+
 
 def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
     r"""Return full path to the user-specific data dir for this application.
@@ -89,7 +95,7 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
         if appname:
             path = os.path.join(path, appname)
     else:
-        path = os.getenv('XDG_DATA_HOME', os.path.expanduser("~/.local/share"))
+        path = getenv('XDG_DATA_HOME', os.path.expanduser("~/.local/share"))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:
@@ -144,7 +150,7 @@ def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
     else:
         # XDG default for $XDG_DATA_DIRS
         # only first, if multipath is False
-        path = os.getenv('XDG_DATA_DIRS',
+        path = getenv('XDG_DATA_DIRS',
                          os.pathsep.join(['/usr/local/share', '/usr/share']))
         pathlist = [os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)]
         if appname:
@@ -199,7 +205,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
         if appname:
             path = os.path.join(path, appname)
     else:
-        path = os.getenv('XDG_CONFIG_HOME', os.path.expanduser("~/.config"))
+        path = getenv('XDG_CONFIG_HOME', os.path.expanduser("~/.config"))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:
@@ -248,7 +254,7 @@ def site_config_dir(appname=None, appauthor=None, version=None, multipath=False)
     else:
         # XDG default for $XDG_CONFIG_DIRS
         # only first, if multipath is False
-        path = os.getenv('XDG_CONFIG_DIRS', '/etc/xdg')
+        path = getenv('XDG_CONFIG_DIRS', '/etc/xdg')
         pathlist = [os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)]
         if appname:
             if version:
@@ -311,7 +317,7 @@ def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
         if appname:
             path = os.path.join(path, appname)
     else:
-        path = os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache'))
+        path = getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache'))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:
@@ -353,7 +359,7 @@ def user_state_dir(appname=None, appauthor=None, version=None, roaming=False):
     if system in ["win32", "darwin"]:
         path = user_data_dir(appname, appauthor, None, roaming)
     else:
-        path = os.getenv('XDG_STATE_HOME', os.path.expanduser("~/.local/state"))
+        path = getenv('XDG_STATE_HOME', os.path.expanduser("~/.local/state"))
         if appname:
             path = os.path.join(path, appname)
     if appname and version:


### PR DESCRIPTION
See #130

As per the XDG spec. Previously, empty variables would be used as-is.