### PR TITLE
Remove unnecessary use of pywin32 for loading Windows folder

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -539,13 +539,15 @@ def _get_win_folder_with_jna(csidl_name):
 if system == "win32":
     try:
         from ctypes import windll
-        _get_win_folder = _get_win_folder_with_ctypes
     except ImportError:
         try:
             import com.sun.jna
-            _get_win_folder = _get_win_folder_with_jna
         except ImportError:
             _get_win_folder = _get_win_folder_from_registry
+        else:
+            _get_win_folder = _get_win_folder_with_jna
+    else:
+        _get_win_folder = _get_win_folder_with_ctypes
 
 
 #---- self test code

--- a/appdirs.py
+++ b/appdirs.py
@@ -484,33 +484,6 @@ def _get_win_folder_from_registry(csidl_name):
     return dir
 
 
-def _get_win_folder_with_pywin32(csidl_name):
-    from win32com.shell import shellcon, shell
-    dir = shell.SHGetFolderPath(0, getattr(shellcon, csidl_name), 0, 0)
-    # Try to make this a unicode path because SHGetFolderPath does
-    # not return unicode strings when there is unicode data in the
-    # path.
-    try:
-        dir = unicode(dir)
-
-        # Downgrade to short path name if have highbit chars. See
-        # <http://bugs.activestate.com/show_bug.cgi?id=85099>.
-        has_high_char = False
-        for c in dir:
-            if ord(c) > 255:
-                has_high_char = True
-                break
-        if has_high_char:
-            try:
-                import win32api
-                dir = win32api.GetShortPathName(dir)
-            except ImportError:
-                pass
-    except UnicodeError:
-        pass
-    return dir
-
-
 def _get_win_folder_with_ctypes(csidl_name):
     import ctypes
 
@@ -565,18 +538,14 @@ def _get_win_folder_with_jna(csidl_name):
 
 if system == "win32":
     try:
-        import win32com.shell
-        _get_win_folder = _get_win_folder_with_pywin32
+        from ctypes import windll
+        _get_win_folder = _get_win_folder_with_ctypes
     except ImportError:
         try:
-            from ctypes import windll
-            _get_win_folder = _get_win_folder_with_ctypes
+            import com.sun.jna
+            _get_win_folder = _get_win_folder_with_jna
         except ImportError:
-            try:
-                import com.sun.jna
-                _get_win_folder = _get_win_folder_with_jna
-            except ImportError:
-                _get_win_folder = _get_win_folder_from_registry
+            _get_win_folder = _get_win_folder_from_registry
 
 
 #---- self test code


### PR DESCRIPTION
Another attempt at https://github.com/ActiveState/appdirs/pull/118 cc @pradyunsg

Closes https://github.com/ActiveState/appdirs/pull/107 (I ran into something similar)
Closes https://github.com/ActiveState/appdirs/issues/108

It's unclear who's maintaining this so cc @zoofood @daved @rawktron @MDrakos @Naatan @autarch @jdufresne 

Could we also get a release? I saw https://github.com/ActiveState/appdirs/issues/79, indicating this library may not be getting the love it deserves. That is quite unfortunate since many projects rely on `appdirs`:

```
ofek@ozone ~\Desktop $ pypinfo --days 365 appdirs
Served from cache: False
Data processed: 638.08 GiB
Data billed: 638.08 GiB
Estimated cost: $3.12

| download_count |
| -------------- |
|     39,354,264 |
```