### PR TITLE
Replace use of deprecated 'setup.py test'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ python:
   - "3.8"
   - "pypy3"
 
-script: python setup.py test
+script: python -m unittest discover

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get -y update && apt-get -y install python3-setuptools && \
 
 WORKDIR /app
 ADD . /app
-RUN python setup.py install && python setup.py test
-RUN python3 setup.py install && python3 setup.py test
+RUN python setup.py install && python -m unittest discover
+RUN python3 setup.py install && python3 -m unittest
 
 RUN python -m appdirs
 RUN python3 -m appdirs

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 envlist = py{27,py,35,36,37,38,py3}
 
 [testenv]
-commands = python setup.py test
+commands = {envpython} -m unittest discover


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used. Now use unittest as the test entry
point.