### PR TITLE
Remove shebang from nonexecutable script

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2005-2010 ActiveState Software Inc.
 # Copyright (c) 2013 Eddy Petrișor


### PR DESCRIPTION
When packaging appdirs and pip (which bundles it) in Fedora, we have realized
that there is a nonexecuatble file with a shebang line.

It seems that the primary purpose of this file is to be imported from Python
code or to be executed via `python appdirs.py` or `python -m
appdirs` and hence the shebang appears to be unnecessary.

Shebangs are hard to handle when doing downstream packaging, because it makes
sense for upstream to use `#!/usr/bin/env python` while in the RPM package, we
need to avoid that and use a more specific interpreter. Since the shebang was
unused, I propose to remove it to avoid the problems.
