### PR TITLE
add site-level state (and/or cache) dir

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -318,6 +318,54 @@ def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
     return path
 
 
+def site_state_dir(appname=None, appauthor=None, version=None):
+    r"""Return full path to the user-shared state dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+
+    Typical site data directories are:
+        Mac OS X:   /Library/Application Support/<AppName>/state
+        Unix:       /var/lib/<AppName>
+        Win XP:     C:\Documents and Settings\All Users\Application Data\<AppAuthor>\<AppName>\State
+        Vista:      (Fail! "C:\ProgramData" is a hidden *system* directory on Vista.)
+        Win 7:      C:\ProgramData\<AppAuthor>\<AppName>\State   # Hidden, but writeable on Win 7.
+
+    For Unix, this does not have an $XDG_STATE_DIR default
+
+    WARNING: Do not use this on Windows. See the Vista-Fail note above for why.
+    """
+    if system == "win32":
+        if appauthor is None:
+            appauthor = appname
+        path = os.path.normpath(_get_win_folder("CSIDL_COMMON_APPDATA"))
+        if appname:
+            if appauthor is not False:
+                path = os.path.join(path, appauthor, appname, 'State')
+            else:
+                path = os.path.join(path, appname, 'State')
+    elif system == 'darwin':
+        path = os.path.expanduser('/Library/Application Support')
+        if appname:
+            path = os.path.join(path, appname, 'State')
+    else:
+        path = '/var/lib'
+        if appname:
+            path = os.path.join(path, appname)
+    if appname and version:
+        path = os.path.join(path, version)
+    return path
+
+
 def user_state_dir(appname=None, appauthor=None, version=None, roaming=False):
     r"""Return full path to the user-specific state dir for this application.
 
@@ -452,6 +500,11 @@ class AppDirs(object):
                               version=self.version)
 
     @property
+    def site_state_dir(self):
+        return site_state_dir(self.appname, self.appauthor,
+                              version=self.version)
+
+    @property
     def user_log_dir(self):
         return user_log_dir(self.appname, self.appauthor,
                             version=self.version)
@@ -561,7 +614,8 @@ if __name__ == "__main__":
              "user_state_dir",
              "user_log_dir",
              "site_data_dir",
-             "site_config_dir")
+             "site_config_dir",
+             "site_state_dir")
 
     print("-- app dirs %s --" % __version__)
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -23,6 +23,8 @@ class Test_AppDir(unittest.TestCase):
         self.assertIsInstance(
             appdirs.user_state_dir('MyApp', 'MyCompany'), STRING_TYPE)
         self.assertIsInstance(
+            appdirs.site_state_dir('MyApp', 'MyCompany'), STRING_TYPE)
+        self.assertIsInstance(
             appdirs.user_log_dir('MyApp', 'MyCompany'), STRING_TYPE)
 
     def test_dirs(self):
@@ -31,6 +33,7 @@ class Test_AppDir(unittest.TestCase):
         self.assertIsInstance(dirs.site_data_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_cache_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_state_dir, STRING_TYPE)
+        self.assertIsInstance(dirs.site_state_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_log_dir, STRING_TYPE)
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py{27,py,35,36,37,38,py3}
+# skip_missing_interpreters = true
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
* use '/var/lib/AppName' dir on Linux
* use site_data with appended 'State' dir on non-Linux platforms

Hi, and thanks for the useful package.  I just started tweaking a python daemon for systemd and it turns out this would be even *more* useful if it had support for site-level 'state' and 'cache' directories.  Since XDG doesn't really define either one, I just made a simple version for state data (cache could be the same, at least without extending the XDG spec a little more).