### PR TITLE
add pathlib support

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -478,7 +478,7 @@ def _pathlib_wrapper(func):
         return inner
 
     except ImportError:
-        return fun
+        return func
 
 
 site_config_path = _pathlib_wrapper(site_config_dir)

--- a/appdirs.py
+++ b/appdirs.py
@@ -457,6 +457,76 @@ class AppDirs(object):
                             version=self.version)
 
 
+#---- pathlib stuff
+
+def _pathlib_wrapper(func):
+
+    try:
+        import functools
+        import pathlib
+        import inspect
+        signature = inspect.signature(func)
+
+        def inner(*args, **kwargs):
+            ba = signature.bind_partial(*args, **kwargs)
+            ba.apply_defaults()
+            return pathlib.Path(func(*ba.args, **ba.kwargs))
+
+        inner.__signature__ = signature
+        inner.__doc__ = func.__doc__
+        inner.__name__ = func.__name__.replace("dir", "path")
+        return inner
+
+    except ImportError:
+        return fun
+
+
+site_config_path = _pathlib_wrapper(site_config_dir)
+site_data_path = _pathlib_wrapper(site_data_dir)
+user_cache_path = _pathlib_wrapper(user_cache_dir)
+user_config_path = _pathlib_wrapper(user_config_dir)
+user_data_path = _pathlib_wrapper(user_data_dir)
+user_log_path = _pathlib_wrapper(user_log_dir)
+user_state_path = _pathlib_wrapper(user_state_dir)
+
+
+class AppPaths(AppDirs):
+
+    @property
+    def user_data_dir(self):
+        return user_data_path(self.appname, self.appauthor,
+                              version=self.version, roaming=self.roaming)
+
+    @property
+    def site_data_dir(self):
+        return site_data_path(self.appname, self.appauthor,
+                              version=self.version, multipath=self.multipath)
+
+    @property
+    def user_config_dir(self):
+        return user_config_path(self.appname, self.appauthor,
+                                version=self.version, roaming=self.roaming)
+
+    @property
+    def site_config_dir(self):
+        return site_config_path(self.appname, self.appauthor,
+                                version=self.version, multipath=self.multipath)
+
+    @property
+    def user_cache_dir(self):
+        return user_cache_path(self.appname, self.appauthor,
+                               version=self.version)
+
+    @property
+    def user_state_dir(self):
+        return user_state_path(self.appname, self.appauthor,
+                               version=self.version)
+
+    @property
+    def user_log_dir(self):
+        return user_log_path(self.appname, self.appauthor,
+                             version=self.version)
+
 #---- internal support stuff
 
 def _get_win_folder_from_registry(csidl_name):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,7 +5,7 @@ import appdirs
 if sys.version_info[0] < 3:
     STRING_TYPE = basestring
     PATH_TYPE = basestring
-elif sys.version_info[1] < 4:
+elif sys.version_info[0] == 3 and sys.version_info[1] < 4:
     STRING_TYPE = str
     PATH_TYPE = str
 else:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,7 +5,7 @@ import appdirs
 if sys.version_info[0] < 3:
     STRING_TYPE = basestring
     PATH_TYPE = basestring
-elif sys.version_info[0] == 3 and sys.version_info[1] < 4:
+elif sys.version_info < (3, 4):
     STRING_TYPE = str
     PATH_TYPE = str
 else:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -4,8 +4,14 @@ import appdirs
 
 if sys.version_info[0] < 3:
     STRING_TYPE = basestring
-else:
+    PATH_TYPE = basestring
+if sys.version_info[1] < 4:
     STRING_TYPE = str
+    PATH_TYPE = str
+else:
+    import pathlib
+    STRING_TYPE = str
+    PATH_TYPE = pathlib.Path
 
 
 class Test_AppDir(unittest.TestCase):
@@ -25,6 +31,18 @@ class Test_AppDir(unittest.TestCase):
         self.assertIsInstance(
             appdirs.user_log_dir('MyApp', 'MyCompany'), STRING_TYPE)
 
+    def test_path_helpers(self):
+        self.assertIsInstance(
+            appdirs.user_data_path('MyApp', 'MyCompany'), PATH_TYPE)
+        self.assertIsInstance(
+            appdirs.site_data_path('MyApp', 'MyCompany'), PATH_TYPE)
+        self.assertIsInstance(
+            appdirs.user_cache_path('MyApp', 'MyCompany'), PATH_TYPE)
+        self.assertIsInstance(
+            appdirs.user_state_path('MyApp', 'MyCompany'), PATH_TYPE)
+        self.assertIsInstance(
+            appdirs.user_log_path('MyApp', 'MyCompany'), PATH_TYPE)
+
     def test_dirs(self):
         dirs = appdirs.AppDirs('MyApp', 'MyCompany', version='1.0')
         self.assertIsInstance(dirs.user_data_dir, STRING_TYPE)
@@ -32,6 +50,15 @@ class Test_AppDir(unittest.TestCase):
         self.assertIsInstance(dirs.user_cache_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_state_dir, STRING_TYPE)
         self.assertIsInstance(dirs.user_log_dir, STRING_TYPE)
+
+    def test_paths(self):
+        paths = appdirs.AppPaths('MyApp', 'MyCompany', version='1.0')
+        self.assertIsInstance(paths.user_data_dir, PATH_TYPE)
+        self.assertIsInstance(paths.site_data_dir, PATH_TYPE)
+        self.assertIsInstance(paths.user_cache_dir, PATH_TYPE)
+        self.assertIsInstance(paths.user_state_dir, PATH_TYPE)
+        self.assertIsInstance(paths.user_log_dir, PATH_TYPE)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -5,7 +5,7 @@ import appdirs
 if sys.version_info[0] < 3:
     STRING_TYPE = basestring
     PATH_TYPE = basestring
-if sys.version_info[1] < 4:
+elif sys.version_info[1] < 4:
     STRING_TYPE = str
     PATH_TYPE = str
 else:


### PR DESCRIPTION
See also #120, #123 

I'd really like pathlib support, so I thought I'd try my hand at an implementation to see if I can get something merged. This implementation builds off of the comments made in #123 by having completely separate functions / class so that current behavior will not change at all.

Currently my implementation falls back on returning strings if it fails to import pathlib. Is this desired behavior, or would you rather raise an exception if pathlib isn't available? We could also move pathlib to another file `_pathlib.py` and only import these functions / class into the appdirs namespace if pathlib is available.