### PR TITLE
Explicitly decode appdirs.py as UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from io import open
 import os
 # appdirs is a dependency of setuptools, so allow installing without it.
 try:
@@ -9,7 +10,7 @@ import ast
 
 
 def read(fname):
-    inf = open(os.path.join(os.path.dirname(__file__), fname))
+    inf = open(os.path.join(os.path.dirname(__file__), fname), encoding='utf8')
     out = "\n" + inf.read().replace("\r\n", "\n")
     inf.close()
     return out


### PR DESCRIPTION
When setup.py reads appdirs.py without an encoding defined, it can sometimes fail having guessed the wrong encoding. For example:

    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc8 in position 129: ordinal not in range(128)

Whereas the builtin `open` does not accept the `encoding` argument until 3.0, `io.open` supports `encoding` under all versions supported by appdirs.