### PR TITLE
Add os.environ fallback for Jython

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -535,6 +535,15 @@ def _get_win_folder_with_jna(csidl_name):
 
     return dir
 
+def _get_win_folder_from_environ(csidl_name):
+    env_var_name = {
+        "CSIDL_APPDATA": "APPDATA",
+        "CSIDL_COMMON_APPDATA": "ALLUSERSPROFILE",
+        "CSIDL_LOCAL_APPDATA": "LOCALAPPDATA",
+    }[csidl_name]
+
+    return os.environ[env_var_name]
+
 if system == "win32":
     try:
         from ctypes import windll
@@ -542,7 +551,15 @@ if system == "win32":
         try:
             import com.sun.jna
         except ImportError:
-            _get_win_folder = _get_win_folder_from_registry
+            try:
+                if PY3:
+                  import winreg as _winreg
+                else:
+                  import _winreg
+            except ImportError:
+                _get_win_folder = _get_win_folder_from_environ
+            else:
+                _get_win_folder = _get_win_folder_from_registry
         else:
             _get_win_folder = _get_win_folder_with_jna
     else:


### PR DESCRIPTION
This is a proposed fix for issue #154 

Provides an additional fallback for Windows if ctypes, JNA, and winreg all fail.

Tested and works as expected in Windows 10 with Jython 2.7.2.  Also tested to verify prior behavior is unchanged against Jython 2.7.2 with JNA and CPython 3.8.5.

This also will fix the downstream pip issue, where pip is currently broken in Jython with a standard Java install.