### PR TITLE
Android support

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -605,8 +605,8 @@ if system == "win32":
 
 elif system == "android":
     try:
-        from jnius import autoclass
-    except ImportError:
+        _get_android_folder_with_jnius()
+    except:
         _get_android_folder = _get_android_folder_brute_path
     else:
         _get_android_folder = _get_android_folder_with_jnius


### PR DESCRIPTION
See #95 issue for more information

Logs of tests (android 10, Samsung J4 2018, SM-J400F):
- Termux (v0.101):
    - [Tox Python 2 and 3](https://pastebin.com/PE1Pzrw6) (passed)
    - [Self tests (\_\_main\_\_)](https://pastebin.com/Dqa8UKyz) (PATH brute, passed)
- Pydriod 3 (v4.01_arm):
    - [Tox Python 3](https://pastebin.com/hMKkg9eK) (first fail, in `/sdcard` directory)
    - [Tox Python 3](https://pastebin.com/YSudtWgn) (second fail, in `app_HOME` directory, home directory of Pydroid)
    - [Self tests (\_\_main\_\_)](https://pastebin.com/e81JsDZL) (PATH brute, passed)
- Pydroid 2 (v2.0_arm):
    - [Self tests (\_\_main\_\_)](https://pastebin.com/iFDxXt6X) (PATH brute, passed)
- Custom app built with P4A (v2020.06.02):
    - [Self tests (\_\_main\_\_)](https://pastebin.com/LgC6urVX) (Via pyjnius, passed)
    - [App source](https://pastebin.com/PrNTQiEP)
    - [.P4A configuration file](https://pastebin.com/FfbcADry)
    - [GZIPped APK](https://github.com/ActiveState/appdirs/files/6790736/appdirs.apk.gz)