### PR TITLE
Full check of win32com

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -557,7 +557,7 @@ def _get_win_folder_with_jna(csidl_name):
 
 if system == "win32":
     try:
-        import win32com.shell
+        from win32com.shell import shellcon, shell
         _get_win_folder = _get_win_folder_with_pywin32
     except ImportError:
         try:


### PR DESCRIPTION
## Description
There are cases when `win32com.shell` is available but import of `shellcon` or `shell` cause crashes. e.g. when pywin is compiled for different binary. In our case we use appdirs in multiple different pythons where we can't affect it's version.

## Changes
Try import all needed parts for pywin getter instead of checking just `import win32com.shell` .