### PR TITLE
Fix config paths on macOS

### DIFF
--- a/appdirs.py
+++ b/appdirs.py
@@ -184,7 +184,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
             for a discussion of issues.
 
     Typical user config directories are:
-        Mac OS X:               ~/Library/Preferences/<AppName>
+        Mac OS X:               ~/Library/Application Support/<AppName>
         Unix:                   ~/.config/<AppName>     # or in $XDG_CONFIG_HOME, if defined
         Win *:                  same as user_data_dir
 
@@ -194,7 +194,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
     if system == "win32":
         path = user_data_dir(appname, appauthor, None, roaming)
     elif system == 'darwin':
-        path = os.path.expanduser('~/Library/Preferences/')
+        path = os.path.expanduser('~/Library/Application Support/')
         if appname:
             path = os.path.join(path, appname)
     else:
@@ -241,7 +241,7 @@ def site_config_dir(appname=None, appauthor=None, version=None, multipath=False)
         if appname and version:
             path = os.path.join(path, version)
     elif system == 'darwin':
-        path = os.path.expanduser('/Library/Preferences')
+        path = os.path.expanduser('/Library/Application Support')
         if appname:
             path = os.path.join(path, appname)
     else:


### PR DESCRIPTION
It looks like the config dir should be `~/Library/Application Support`.

A few other projects as examples:
* https://github.com/dirs-dev/dirs-rs/blob/999efde766ed370a60c58145711db728ae9c04e8/src/mac.rs#L8
* https://github.com/adrg/xdg/blob/31e6a328d142d3b8ed43fda69c4f2b55e77d8e79/paths_darwin.go#L28
* https://github.com/dirs-dev/directories-jvm/blob/917e954cf94442399409ea384e94d658b57682b6/src/main/java/dev/dirs/BaseDirectories.java#L268

closes: #185 